### PR TITLE
Refactor WatchPage and UnifiedPlayer components; integrate Pahe API f…

### DIFF
--- a/app/(shared)/watch/[id]/page.tsx
+++ b/app/(shared)/watch/[id]/page.tsx
@@ -1,27 +1,14 @@
 "use client";
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import {
-  fetchAnimeInfo,
-  fetchAnimeEpisodes,
-  fetchAnimeStreamingLinks,
-} from "@/hooks/useApi";
+import { fetchAnimeData } from "@/hooks/useApi";
+import { usePaheEpisodes } from "@/hooks/usePaheApi";
 import { UnifiedPlayer } from "@/components/watch/video/UnifiedPlayer";
 import { EpisodeList } from "@/components/watch/EpisodeList";
-import { MediaSource } from "@/components/watch/video/MediaSource";
 import { WatchAnimeData } from "@/components/watch/WatchAnimeData";
 import { AnimeDataList } from "@/components/watch/AnimeDataList";
-import { StatusIndicator } from "@/components/shared/StatusIndicator";
-import {
-  ArrowLeft,
-  ChevronLeft,
-  ChevronRight,
-  Settings2,
-  Monitor,
-  Smartphone,
-} from "lucide-react";
-import { useCountdown } from "@/hooks/useCountdown";
+import { ArrowLeft } from "lucide-react";
 import Loader from "@/app/loading";
 
 interface PageProps {
@@ -32,9 +19,11 @@ interface PageProps {
 
 interface Episode {
   id: string;
-  title: string;
+  episode: number;
   number: number;
-  image: string;
+  session: string;
+  title?: string;
+  image?: string;
   description?: string;
   createdAt?: string;
   url?: string;
@@ -65,21 +54,25 @@ export default function WatchPage({ params }: PageProps) {
   const [animeId, setAnimeId] = useState<string>("");
   const [episodeNumber, setEpisodeNumber] = useState<number>(1);
   const [animeInfo, setAnimeInfo] = useState<AnimeInfo | null>(null);
-  const [episodes, setEpisodes] = useState<Episode[]>([]);
   const [currentEpisode, setCurrentEpisode] = useState<Episode | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [animeLoading, setAnimeLoading] = useState(true);
+  const [animeError, setAnimeError] = useState<string | null>(null);
+  const [episodeError, setEpisodeError] = useState<string | null>(null);
 
-  // Player settings
-  const [serverName, setServerName] = useState<string>("hd-1");
-  const [language, setLanguage] = useState<string>("sub");
-  const [downloadLink, setDownloadLink] = useState<string>("");
-  const nextEpisodeAiringTime =
-    animeInfo && animeInfo.nextAiringEpisode
-      ? animeInfo.nextAiringEpisode.airingTime * 1000
-      : null;
-  const nextEpisodenumber = animeInfo?.nextAiringEpisode?.episode;
-  const countdown = useCountdown(nextEpisodeAiringTime);
+  const { data: paheEpisodesResponse, loading: episodesLoading, error: episodesError } =
+    usePaheEpisodes(animeInfo?.malId);
+
+  const episodes = useMemo<Episode[]>(() => {
+    return (paheEpisodesResponse?.episodes || []).map((episode) => ({
+      id: episode.session,
+      episode: episode.episode,
+      number: episode.episode,
+      session: episode.session,
+      title: episode.title,
+      image: episode.snapshot,
+      url: episode.link,
+    }));
+  }, [paheEpisodesResponse]);
 
   // Resolve params and query parameters
   useEffect(() => {
@@ -102,75 +95,73 @@ export default function WatchPage({ params }: PageProps) {
             { scroll: false }
           );
         }
-
       } catch (err) {
-        setError("Failed to load page parameters.");
-        setLoading(false);
+        setAnimeError("Failed to load page parameters.");
+        setAnimeLoading(false);
       }
     }
 
     resolveParams();
   }, [params, searchParams, router]);
 
-  // Fetch anime info and episodes
   useEffect(() => {
     if (!animeId) return;
 
     async function fetchData() {
-      setLoading(true);
+      setAnimeLoading(true);
       try {
-        // Fetch anime info
-        const animeData = await fetchAnimeInfo(animeId);
+        const animeData = await fetchAnimeData(animeId);
         setAnimeInfo(animeData);
-
-        // Fetch episodes based on language preference
-        const isDub = language === "dub";
-        const episodesData = animeData.episodes;
-
-        if (episodesData && Array.isArray(episodesData)) {
-          const transformedEpisodes = episodesData.map((ep: any) => ({
-            id: ep.id,
-            title: ep.title || `Episode ${ep.number}`,
-            number: ep.number,
-            image: ep.image,
-            createdAt: ep.createdAt,
-            url: ep.url,
-          }));
-          setEpisodes(transformedEpisodes);
-
-          // Find and set current episode
-          const currentEp = transformedEpisodes.find(
-            (ep: Episode) => ep.number === episodeNumber
-          );
-          if (currentEp) {
-            setCurrentEpisode(currentEp);
-          } else if (transformedEpisodes.length > 0) {
-            // Fallback to first episode if specified episode not found
-            setCurrentEpisode(transformedEpisodes[0]);
-            setEpisodeNumber(transformedEpisodes[0].number);
-          }
-        }
-
-        setError(null);
+        setAnimeError(null);
       } catch (err) {
-        setError("Failed to load anime information. Please try again later.");
+        setAnimeError("Failed to load anime information. Please try again later.");
       } finally {
-        setLoading(false);
+        setAnimeLoading(false);
       }
     }
 
     fetchData();
-  }, [animeId, language]);
+  }, [animeId]);
 
-  // Update current episode when episode number changes
   useEffect(() => {
-    if (episodes.length > 0) {
-      const episode = episodes.find((ep) => ep.number === episodeNumber);
-      if (episode) {
-        setCurrentEpisode(episode);
+    if (!episodes.length) {
+      setCurrentEpisode(null);
+      if (!episodesLoading && paheEpisodesResponse) {
+        setEpisodeError("No episodes were returned for this anime.");
       }
+      return;
     }
-  }, [episodeNumber, episodes]);
+
+    const episode = episodes.find((ep) => ep.episode === episodeNumber);
+    if (episode) {
+      setCurrentEpisode(episode);
+      setEpisodeError(null);
+      return;
+    }
+
+    const firstEpisode = episodes[0];
+    setCurrentEpisode(firstEpisode);
+    setEpisodeNumber(firstEpisode.episode);
+  }, [episodeNumber, episodes, episodesLoading, paheEpisodesResponse]);
+
+  useEffect(() => {
+    if (!animeId || episodes.length === 0) return;
+
+    const matchedEpisode = episodes.find((ep) => ep.episode === episodeNumber);
+    if (matchedEpisode) {
+      setEpisodeError(null);
+      return;
+    }
+
+    const firstEpisode = episodes[0];
+    setEpisodeNumber(firstEpisode.episode);
+
+    const currentParams = new URLSearchParams(searchParams.toString());
+    currentParams.set("ep", firstEpisode.episode.toString());
+    router.replace(`/watch/${animeId}?${currentParams.toString()}`, {
+      scroll: false,
+    });
+  }, [animeId, episodeNumber, episodes, router, searchParams]);
 
   // Save to watch history - separate function
   const saveToWatchHistory = useCallback((episode: Episode) => {
@@ -181,7 +172,7 @@ export default function WatchPage({ params }: PageProps) {
         localStorage.getItem("watch-history") || "{}"
       );
       watchHistory[animeId] = {
-        episodeNumber: episode.number,
+        episodeNumber: episode.episode,
         episodeId: episode.id,
         timestamp: Date.now(),
         animeTitle: animeInfo?.title?.english || animeInfo?.title?.romaji,
@@ -207,12 +198,12 @@ export default function WatchPage({ params }: PageProps) {
     (episodeId: string) => {
       const episode = episodes.find((ep) => ep.id === episodeId);
       if (episode) {
-        setEpisodeNumber(episode.number);
+        setEpisodeNumber(episode.episode);
         setCurrentEpisode(episode);
 
         // Update URL with new episode number
         const currentParams = new URLSearchParams(searchParams.toString());
-        currentParams.set("ep", episode.number.toString());
+        currentParams.set("ep", episode.episode.toString());
         router.replace(`/watch/${animeId}?${currentParams.toString()}`, {
           scroll: false,
         });
@@ -223,11 +214,10 @@ export default function WatchPage({ params }: PageProps) {
     [episodes, animeId, router, searchParams]
   );
 
-  // Navigation functions
   const goToPreviousEpisode = useCallback(() => {
     if (episodeNumber > 1) {
       const prevEpisode = episodes.find(
-        (ep) => ep.number === episodeNumber - 1
+        (ep) => ep.episode === episodeNumber - 1
       );
       if (prevEpisode) {
         handleEpisodeSelect(prevEpisode.id);
@@ -236,45 +226,27 @@ export default function WatchPage({ params }: PageProps) {
   }, [episodeNumber, episodes, handleEpisodeSelect]);
 
   const goToNextEpisode = useCallback(() => {
-    const nextEpisode = episodes.find((ep) => ep.number === episodeNumber + 1);
+    const nextEpisode = episodes.find((ep) => ep.episode === episodeNumber + 1);
     if (nextEpisode) {
       handleEpisodeSelect(nextEpisode.id);
     }
   }, [episodeNumber, episodes, handleEpisodeSelect]);
 
-  // Handle episode end (for auto-next feature)
   const handleEpisodeEnd = useCallback(async () => {
     goToNextEpisode();
   }, [goToNextEpisode]);
 
-  // Update download link callback
-  const updateDownloadLink = useCallback((link: string) => {
-    setDownloadLink(link);
-  }, []);
-
-  // Handle server name change
-  const handleServerChange = useCallback((newServerName: string) => {
-    setServerName(newServerName);
-  }, []);
-
-  // Handle language change
-  const handleLanguageChange = useCallback((newLanguage: string) => {
-    setLanguage(newLanguage);
-  }, []);
-
-  // Loading state
-  if (loading) {
-    return (
-      <Loader/>
-    );
+  if (animeLoading || episodesLoading) {
+    return <Loader />;
   }
 
-  // Error state
-  if (error) {
+  if (animeError || episodesError || episodeError) {
     return (
       <div className="min-h-screen bg-background p-4">
         <div className="max-w-4xl mx-auto text-center py-20">
-          <div className="text-destructive text-xl mb-4">{error}</div>
+          <div className="text-destructive text-xl mb-4">
+            {animeError || episodesError || episodeError}
+          </div>
           <Link
             href="/"
             className="inline-flex items-center gap-2 text-primary hover:underline"
@@ -294,30 +266,21 @@ export default function WatchPage({ params }: PageProps) {
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
-      
-
-      {/* Main Content */}
       <div className="max-w-9xl mx-auto mt-16">
         <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {/* Video Player and Controls */}
           <div className="lg:col-span-3 space-y-4">
-            {/* Video Player */}
             <div className="relative rounded-lg w-full">
               {currentEpisode ? (
                 <UnifiedPlayer
                   episodeId={currentEpisode.id}
+                  anilistId={animeId}
                   banner={animeInfo.cover}
                   malId={animeInfo.malId}
-                  updateDownloadLink={updateDownloadLink}
                   onEpisodeEnd={handleEpisodeEnd}
                   onPrevEpisode={goToPreviousEpisode}
                   onNextEpisode={goToNextEpisode}
                   animeTitle={animeTitle}
                   episodeNumber={episodeNumber.toString()}
-                  serverName={serverName}
-                  language={language}
-                  defaultMode="advanced"
                 />
               ) : (
                 <div className="flex items-center justify-center h-full">
@@ -328,34 +291,10 @@ export default function WatchPage({ params }: PageProps) {
                 </div>
               )}
             </div>
-
-            {/* Media Source Controls */}
-            <div className="">
-              <MediaSource
-                serverName={serverName}
-                setServerName={handleServerChange}
-                language={language}
-                setLanguage={handleLanguageChange}
-                
-                episodeId={episodeNumber.toString()}
-                airingTime={
-                animeInfo && (animeInfo.status === 'RELEASING' || animeInfo.status === 'Ongoing')
-                  ? countdown
-                  : undefined
-              }
-              nextEpisodenumber={nextEpisodenumber}
-              />
-            </div>
-
-            {/* Anime Details */}
             <WatchAnimeData animeData={animeInfo} />
           </div>
-
-          {/* Sidebar */}
           <div className="space-y-6">
-            {/* Episode List */}
             <div className="bg-card border border-border rounded-lg">
-              
               <div className="max-h-96 overflow-hidden">
                 <EpisodeList
                   animeId={animeId}
@@ -366,8 +305,6 @@ export default function WatchPage({ params }: PageProps) {
                 />
               </div>
             </div>
-
-            {/* Related Anime */}
             <AnimeDataList animeData={animeInfo} />
           </div>
         </div>

--- a/components/watch/video/UnifiedPlayer.tsx
+++ b/components/watch/video/UnifiedPlayer.tsx
@@ -1,25 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import "./PlayerStyles.css";
-import {
-  MediaPlayer,
-  MediaProvider,
-  Track,
-  type MediaPlayerInstance,
-  useMediaStore,
-} from "@vidstack/react";
+import { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
-import { fetchAnimeStreamingLinks, MEDIA_PROXY_URL } from "@/hooks/useApi";
-import {
-  DefaultAudioLayout,
-  defaultLayoutIcons,
-  DefaultVideoLayout,
-} from "@vidstack/react/player/layouts/default";
 import { TbPlayerTrackPrev, TbPlayerTrackNext } from "react-icons/tb";
-import { FaCheck, FaExternalLinkAlt } from "react-icons/fa";
+import { FaCheck } from "react-icons/fa";
 import { RiCheckboxBlankFill } from "react-icons/ri";
-import { MdSwapHoriz } from "react-icons/md";
 import { CustomLoader } from "./Loader";
 
 const Button = styled.button<{ $autoskip?: boolean; $active?: boolean }>`
@@ -88,10 +73,24 @@ const IframeContainer = styled.div`
   }
 `;
 
-type PlayerMode = 'advanced' | 'iframe';
+const MEGAPLAY_EMBED_BASE = "https://megaplay.buzz/stream/ani";
+const noop = () => {};
+
+function buildMegaPlayEmbedUrl(
+  anilistId?: string | number,
+  episodeNumber?: string | number,
+  language: string = "sub",
+) {
+  if (!anilistId || !episodeNumber) return "";
+
+  const normalizedLanguage = language.toLowerCase() === "dub" ? "dub" : "sub";
+
+  return `${MEGAPLAY_EMBED_BASE}/${encodeURIComponent(String(anilistId))}/${encodeURIComponent(String(episodeNumber))}/${normalizedLanguage}`;
+}
 
 type UnifiedPlayerProps = {
   episodeId: string;
+  anilistId?: string | number;
   category?: string;
   banner?: string;
   malId?: string;
@@ -103,473 +102,73 @@ type UnifiedPlayerProps = {
   animeTitle?: string;
   serverName?: string;
   language?: string;
-  defaultMode?: PlayerMode;
 };
 
-type StreamingSource = {
-  url: string;
-  quality: string;
-};
+export function UnifiedPlayer(props: UnifiedPlayerProps) {
+  const {
+    anilistId,
+    updateDownloadLink = noop,
+    onEpisodeEnd,
+    onPrevEpisode,
+    onNextEpisode,
+    episodeNumber,
+    animeTitle,
+    language = "sub",
+  } = props;
 
-type SkipTime = {
-  interval: {
-    startTime: number;
-    endTime: number;
-  };
-  skipType: string;
-};
-
-export function UnifiedPlayer({
-  episodeId,
-  category = "sub",
-  banner,
-  malId,
-  updateDownloadLink = () => {},
-  onEpisodeEnd,
-  onPrevEpisode,
-  onNextEpisode,
-  episodeNumber,
-  animeTitle,
-  serverName = "hd-1",
-  language = "sub",
-  defaultMode = "advanced",
-}: UnifiedPlayerProps) {
-  const player = useRef<MediaPlayerInstance>(null);
-  const [waiting, setWaiting] = useState(false);
-  const [canPlay, setCanPlay] = useState(false);
-  const [seeking, setSeeking] = useState(false);
-  
-  // Player state
-  const [playerMode, setPlayerMode] = useState<PlayerMode>("advanced"); 
-  const [src, setSrc] = useState<string>("");
-  const [subtitles, setSubtitles] = useState<any>([]);
-  const [vttUrl, setVttUrl] = useState<string>("");
-  const [currentTime, setCurrentTime] = useState<number>(0);
-  const [skipTimes, setSkipTimes] = useState<SkipTime[]>([]);
-  const [totalDuration, setTotalDuration] = useState<number>(0);
-  const [vttGenerated, setVttGenerated] = useState<boolean>(false);
-  const [hasValidHLSLink, setHasValidHLSLink] = useState<boolean>(false);
-  
-  // Player controls
   const [autoPlay, setAutoPlay] = useState<boolean>(true);
   const [autoNext, setAutoNext] = useState<boolean>(true);
-  const [autoSkip, setAutoSkip] = useState<boolean>(false);
   const [showLoader, setShowLoader] = useState<boolean>(true);
-
-  const resolveStreamUrl = (data: any) => {
-    if (typeof data?.link === "string") return data.link;
-    if (typeof data?.link?.file === "string") return data.link.file;
-    if (typeof data?.link?.url === "string") return data.link.url;
-    if (Array.isArray(data?.sources) && data.sources.length > 0) {
-      return data.sources[0]?.url || data.sources[0]?.file || "";
-    }
-    return "";
-  };
-
-  const resolveSubtitleTracks = (data: any) => {
-    const subtitleList = Array.isArray(data?.subtitles) ? data.subtitles : [];
-    const trackList = Array.isArray(data?.tracks) ? data.tracks : [];
-    const merged = [...subtitleList, ...trackList];
-
-    return merged.filter((track: any) => {
-      const kind = (track?.kind || "").toLowerCase();
-      const hasSource = !!(track?.url || track?.file);
-      return hasSource && kind !== "thumbnails";
-    });
-  };
-
-  const animeVideoTitle = animeTitle;
+  const iframeSrc = useMemo(
+    () => buildMegaPlayEmbedUrl(anilistId, episodeNumber, language),
+    [anilistId, episodeNumber, language],
+  );
 
   useEffect(() => {
-    setCurrentTime(parseFloat(localStorage.getItem("currentTime") || "0"));
-    setVttGenerated(false);
-    setHasValidHLSLink(false);
-    
-    // Always try to fetch data first to determine player mode
-    fetchAndSetAnimeSource();
-    
-    return () => {
-      if (vttUrl) URL.revokeObjectURL(vttUrl);
-    };
-  }, [episodeId, malId, updateDownloadLink, serverName, language]);
+    setShowLoader(true);
+  }, [iframeSrc]);
 
   useEffect(() => {
-    if (hasValidHLSLink && autoPlay && player.current && playerMode === "advanced") {
-      player.current
-        .play()
-        .catch((e: Error) => {
-          // Silent error handling for autoplay failure
-        });
-    }
-  }, [autoPlay, src, playerMode, hasValidHLSLink]);
-
-  useEffect(() => {
-    if (hasValidHLSLink && player.current && currentTime && playerMode === "advanced") {
-      player.current.currentTime = currentTime;
-    }
-  }, [currentTime, playerMode, hasValidHLSLink]);
-
-  function onLoadedMetadata() {
-    if (player.current) {
-      const duration = player.current.duration;
-      setTotalDuration(duration);
-      
-      if (skipTimes.length > 0 && vttUrl) {
-        const vttContent = generateWebVTTFromSkipTimes(skipTimes, duration);
-        const blob = new Blob([vttContent], { type: "text/vtt" });
-        
-        URL.revokeObjectURL(vttUrl);
-        const newVttBlobUrl = URL.createObjectURL(blob);
-        setVttUrl(newVttBlobUrl);
-      }
-    }
-  }
-
-  function onTimeUpdate() {
-    if (player.current) {
-      const currentTime = player.current.currentTime;
-      const duration = player.current.duration || 1;
-      const playbackPercentage = (currentTime / duration) * 100;
-      const playbackInfo = {
-        currentTime,
-        playbackPercentage,
-      };
-      const allPlaybackInfo = JSON.parse(
-        localStorage.getItem("all_episode_times") || "{}"
-      );
-      allPlaybackInfo[episodeId] = playbackInfo;
-      localStorage.setItem(
-        "all_episode_times",
-        JSON.stringify(allPlaybackInfo)
-      );
-
-      if (autoSkip && skipTimes.length) {
-        const skipInterval = skipTimes.find(
-          ({ interval }) =>
-            currentTime >= interval.startTime && currentTime < interval.endTime
-        );
-        if (skipInterval) {
-          player.current.currentTime = skipInterval.interval.endTime;
-        }
-      }
-    }
-  }
-
-  function generateWebVTTFromSkipTimes(
-    skipTimes: SkipTime[],
-    totalDuration: number
-  ): string {
-    let vttString = "WEBVTT\n\n";
-    let previousEndTime = 0;
-
-    const sortedSkipTimes = skipTimes.sort(
-      (a, b) => a.interval.startTime - b.interval.startTime
-    );
-
-    sortedSkipTimes.forEach((skipTime, index) => {
-      const { startTime, endTime } = skipTime.interval;
-      const skipType =
-        skipTime.skipType.toUpperCase() === "OP" ? "Opening" : "Outro";
-
-      if (previousEndTime < startTime) {
-        vttString += `${formatTime(previousEndTime)} --> ${formatTime(
-          startTime
-        )}\n`;
-        vttString += `${animeVideoTitle} - Episode ${episodeNumber}\n\n`;
-      }
-
-      vttString += `${formatTime(startTime)} --> ${formatTime(endTime)}\n`;
-      vttString += `${skipType}\n\n`;
-      previousEndTime = endTime;
-
-      if (index === sortedSkipTimes.length - 1 && endTime < totalDuration) {
-        vttString += `${formatTime(endTime)} --> ${formatTime(
-          totalDuration
-        )}\n`;
-        vttString += `${animeVideoTitle} - Episode ${episodeNumber}\n\n`;
-      }
-    });
-
-    return vttString;
-  }
-
-  function convertIntroOutroToSkipTimes(introData?: {start: number, end: number}, outroData?: {start: number, end: number}): SkipTime[] {
-    const skipTimes: SkipTime[] = [];
-    
-    if (introData) {
-      skipTimes.push({
-        interval: {
-          startTime: introData.start,
-          endTime: introData.end
-        },
-        skipType: "op"
-      });
-    }
-    
-    if (outroData) {
-      skipTimes.push({
-        interval: {
-          startTime: outroData.start,
-          endTime: outroData.end
-        },
-        skipType: "ed"
-      });
-    }
-    
-    return skipTimes;
-  }
-
-  async function fetchAndSetAnimeSource() {
-    try {
-      // Transform episode ID for language switching (sub/dub logic)
-      let modifiedEpisodeId = episodeId;
-      
-      if (language === "dub") {
-        modifiedEpisodeId = episodeId.replace(/\$sub$/, "$dub");
-      } else {
-        if (!episodeId.endsWith("$sub")) {
-          modifiedEpisodeId = episodeId.replace(/\$dub$/, "$sub");
-        }
-      }
-
-      const response = await fetchAnimeStreamingLinks(modifiedEpisodeId, serverName, language);
-      
-      if (!response || !response.success || !response.data) {
-        setHasValidHLSLink(false);
-        setPlayerMode("iframe");
-        return;
-      }
-
-      const data = response.data;
-      
-      // Check if we have a valid HLS link from new schema (sources) or legacy fields.
-      const streamUrl = resolveStreamUrl(data);
-      if (streamUrl) {
-        
-        // Validate if it's a proper HLS link
-        if (streamUrl && (streamUrl.includes('.m3u8') || data.linkType === 'hls')) {
-          setSrc(streamUrl);
-          updateDownloadLink(streamUrl);
-          setHasValidHLSLink(true);
-          setPlayerMode("advanced");
-          
-          // Handle subtitles/tracks
-          setSubtitles(resolveSubtitleTracks(data));
-
-          // Handle intro/outro data
-          if (data.intro || data.outro) {
-            const convertedSkipTimes = convertIntroOutroToSkipTimes(
-              data.intro, 
-              data.outro
-            );
-            setSkipTimes(convertedSkipTimes);
-            
-            if (convertedSkipTimes.length > 0) {
-              const estimatedDuration = totalDuration || 1440;
-              const vttContent = generateWebVTTFromSkipTimes(
-                convertedSkipTimes,
-                estimatedDuration
-              );
-              const blob = new Blob([vttContent], { type: "text/vtt" });
-              const vttBlobUrl = URL.createObjectURL(blob);
-              setVttUrl(vttBlobUrl);
-              setVttGenerated(true);
-            }
-          }
-        } else {
-          setHasValidHLSLink(false);
-          setPlayerMode("iframe");
-        }
-      } else {
-        setHasValidHLSLink(false);
-        setPlayerMode("iframe");
-      }
-
-    } catch (error) {
-      setHasValidHLSLink(false);
-      setPlayerMode("iframe");
-    }
-  }
-
-  function formatTime(seconds: number): string {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = Math.floor(seconds % 60);
-    return `${minutes.toString().padStart(2, "0")}:${remainingSeconds
-      .toString()
-      .padStart(2, "0")}`;
-  }
-
-  // Iframe player functions
-  const getIframeSrc = () => {
-    const epMatch = episodeId.match(/ep=(\d+)/);
-    const extractedEpId = epMatch ? epMatch[1] : "";
-    const normalizedServer = serverName.toLowerCase();
-    const domain =
-      normalizedServer === "hd-2" || normalizedServer === "vidstreaming"
-        ? "vidwish.live"
-        : "megaplay.buzz";
-    return `https://${domain}/stream/s-2/${extractedEpId}/${language}`;
-  };
+    updateDownloadLink(iframeSrc);
+  }, [iframeSrc, updateDownloadLink]);
 
   const toggleAutoPlay = () => setAutoPlay(!autoPlay);
   const toggleAutoNext = () => setAutoNext(!autoNext);
-  const toggleAutoSkip = () => setAutoSkip(!autoSkip);
-  
-  // Manual toggle function (only allow if HLS link is available)
-  const togglePlayerMode = () => {
-    if (hasValidHLSLink) {
-      setPlayerMode(prev => prev === "advanced" ? "iframe" : "advanced");
-    }
-  };
-
-  const handlePlaybackEnded = async () => {
-    if (!autoNext) return;
-
-    try {
-      if (player.current && hasValidHLSLink) {
-        player.current.pause();
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      await onEpisodeEnd();
-    } catch (error) {
-      // Silent error handling
-    }
-  };
-
-  useEffect(() => {
-    if (playerMode === "advanced" && hasValidHLSLink) {
-      if (canPlay) {
-        setShowLoader(false);
-      } else if (seeking || waiting) {
-        setShowLoader(true);
-      } else {
-        setShowLoader(true);
-      }
-    } else if (playerMode === "iframe") {
-      // For iframe, we'll handle loading in the iframe onLoad events
-      setShowLoader(true);
-    }
-  }, [canPlay, seeking, waiting, playerMode, hasValidHLSLink]);
 
   return (
     <>
       <PlayerContainer>
-        {playerMode === "advanced" && hasValidHLSLink ? (
-          <div className="relative">
-            <MediaPlayer
-              className="player"
-              title={`${animeVideoTitle} - Episode ${episodeNumber}`}
-              src={{
-                src: `${MEDIA_PROXY_URL}fetch?url=${encodeURIComponent(src)}`,
-                type: 'application/x-mpegurl'
-              }}
-              autoPlay={autoPlay}
-              crossOrigin
-              playsInline
-              onLoadedMetadata={onLoadedMetadata}
-              onTimeUpdate={onTimeUpdate}
-              onWaiting={() => setWaiting(true)}
-              onCanPlay={() => { setCanPlay(true); setWaiting(false); }}
-              onSeeking={() => setSeeking(true)}
-              onSeeked={() => setSeeking(false)}
-              onError={() => {
-                // Avoid logging the raw Vidstack error object; Next devtools tries to stringify it and can crash.
-                console.error('Video player error: switching to iframe fallback');
-                // Fallback to iframe if HLS fails
-                if (hasValidHLSLink) {
-                  setHasValidHLSLink(false);
-                  setPlayerMode("iframe");
-                }
-              }}
-              ref={player}
-              aspectRatio="16/9"
-              load="eager"
-              posterLoad="eager"
-              poster={banner}
-              streamType="on-demand"
-              storage={`player-${episodeId}`}
-              keyTarget="player"
-              onEnded={handlePlaybackEnded}
-            >
-              <MediaProvider>
-                {vttUrl && (
-                  <Track
-                    kind="chapters"
-                    src={vttUrl}
-                    default
-                    label="Skip Times"
-                  />
-                )}
-
-                {subtitles &&
-                  subtitles.map((subtitle: any, index: number) => (
-                    <Track
-                      key={String(index)}
-                      kind="subtitles"
-                      type="vtt"
-                      src={subtitle.file || subtitle.url}
-                      label={subtitle.label || subtitle.lang}
-                      {...(subtitle.default || subtitle.label === "English" || subtitle.lang === "English" ? { default: true } : {})}
-                    />
-                  ))}
-              </MediaProvider>
-
-              {showLoader && <CustomLoader />}
-              
-              <DefaultAudioLayout icons={defaultLayoutIcons} />
-              <DefaultVideoLayout icons={defaultLayoutIcons} />
-            </MediaPlayer>
-          </div>
-        ) : (
-          <IframeContainer>
-            {showLoader && (
-              <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 z-10">
-                <CustomLoader />
-              </div>
-            )}
+        <IframeContainer>
+          {showLoader && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 z-10">
+              <CustomLoader />
+            </div>
+          )}
+          {iframeSrc ? (
             <iframe
-              src={getIframeSrc()}
+              src={iframeSrc}
               width="100%"
               height="100%"
               allowFullScreen
               loading="lazy"
               onLoad={() => setShowLoader(false)}
-              onLoadStart={() => setShowLoader(true)}
             />
-          </IframeContainer>
-        )}
+          ) : (
+            <div className="flex h-full items-center justify-center bg-card text-sm text-muted-foreground">
+              No stream available for this episode.
+            </div>
+          )}
+        </IframeContainer>
       </PlayerContainer>
 
       <div
         id="player-menu"
         className="flex items-center md:gap-2 px-1 md:px-2 overflow-x-auto rounded bg-accent no-scrollbar mt-2"
       >
-        {hasValidHLSLink && (
-          <Button onClick={togglePlayerMode} $active={playerMode === "advanced"} className="flex gap-1">
-            <MdSwapHoriz className="mt-0.5" />
-            {playerMode === "advanced" ? "HLS" : "Iframe"}
-          </Button>
-        )}
-        
-        {!hasValidHLSLink && (
-          <Button disabled className="flex gap-1 opacity-50 cursor-not-allowed">
-            <FaExternalLinkAlt className="mt-0.5" />
-            Iframe Only
-          </Button>
-        )}
-        
         <Button onClick={toggleAutoPlay} className="flex gap-1">
           {autoPlay ? <FaCheck className="mt-0.5" /> : <RiCheckboxBlankFill className="mt-0.5" />}
           Autoplay
         </Button>
-        
-        {playerMode === "advanced" && hasValidHLSLink && (
-          <Button $autoskip onClick={toggleAutoSkip} className="flex gap-1">
-            {autoSkip ? <FaCheck className="mt-0.5" /> : <RiCheckboxBlankFill className="mt-0.5" />}
-            Auto Skip
-          </Button>
-        )}
         
         <Button className="flex gap-1" onClick={onPrevEpisode}>
           <TbPlayerTrackPrev className="mt-0.5" /> Prev

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/hooks/useApi.ts
+++ b/hooks/useApi.ts
@@ -11,9 +11,6 @@ function ensureUrlEndsWithSlash(url: string): string {
 const BASE_URL = ensureUrlEndsWithSlash(
     process.env.NEXT_PUBLIC_BACKEND_URL as string,
 );
-const CF_BACKEND_URL = ensureUrlEndsWithSlash(
-    (process.env.NEXT_PUBLIC_CF_BACKEND_URL || process.env.cf_backend_url || process.env.NEXT_PUBLIC_BACKEND_URL) as string,
-);
 // const STREAM_URL = ensureUrlEndsWithSlash(
 //     process.env.NEXT_PUBLIC_STREAMING_BACKEND_URL as string,
 // );
@@ -446,7 +443,7 @@ export async function fetchAnimeInfo(
     animeId: string,
     provider: string = 'zoro',
 ) {
-    const url = `${CF_BACKEND_URL}anime/info/${animeId}`;
+    const url = `${BASE_URL}anime/info/${animeId}`;
     const cacheKey = generateCacheKey('animeInfo', animeId, provider, 'cf');
 
     const response = await fetchFromProxy(url, animeInfoCache, cacheKey);
@@ -542,7 +539,7 @@ export async function fetchAnimeEpisodes(
     provider: string = 'gogoanime',
     dub: boolean = false,
 ) {
-    const url = `${CF_BACKEND_URL}anime/info/${animeId}`;
+    const url = `${BASE_URL}anime/info/${animeId}`;
     const cacheKey = generateCacheKey(
         'animeEpisodes',
         animeId,
@@ -574,7 +571,7 @@ export async function fetchAnimeEmbeddedEpisodes(episodeId: string, episodeNumbe
     }
 
     const suffix = params.toString() ? `?${params.toString()}` : '';
-    const url = `${CF_BACKEND_URL}anime/servers/${encodeURIComponent(normalizedEpisodeId)}${suffix}`;
+    const url = `${BASE_URL}anime/servers/${encodeURIComponent(normalizedEpisodeId)}${suffix}`;
     const cacheKey = generateCacheKey('animeEmbeddedServers', normalizedEpisodeId, episodeNumberId || '');
 
     const response = await fetchFromProxy(url, fetchAnimeEmbeddedEpisodesCache, cacheKey);
@@ -601,7 +598,7 @@ export async function fetchAnimeStreamingLinks(
                 preferredServer,
             );
 
-            const url = `${CF_BACKEND_URL}anime/sources?episodeId=${encodeURIComponent(candidateEpisodeId)}&server=${encodeURIComponent(resolvedServer)}&category=${encodeURIComponent(category)}`;
+            const url = `${BASE_URL}anime/sources?episodeId=${encodeURIComponent(candidateEpisodeId)}&server=${encodeURIComponent(resolvedServer)}&category=${encodeURIComponent(category)}`;
             const response = await axios.get(url, { headers: { Accept: '*/*' } });
             const normalized = normalizeStreamingResponse(response.data, resolvedServer, category);
 

--- a/hooks/usePaheApi.ts
+++ b/hooks/usePaheApi.ts
@@ -1,0 +1,305 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+const PAHE_API_URL = ensureUrlEndsWithSlash(
+  process.env.NEXT_PUBLIC_PAHE_API_URL || "",
+);
+
+function ensureUrlEndsWithSlash(url: string): string {
+  if (!url) return "";
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+export type PaheEpisode = {
+  id: number;
+  episode: number;
+  session: string;
+  link?: string;
+  duration?: string;
+  audio?: string;
+  snapshot?: string;
+  title?: string;
+};
+
+export type PaheEpisodeListResponse = {
+  anilistId: number;
+  paheId: number;
+  session: string;
+  type: string;
+  title: string;
+  episodes: PaheEpisode[];
+};
+
+export type PaheSource = {
+  url?: string;
+  isM3U8?: boolean;
+  filename?: string;
+  embed?: string;
+  resolution?: string;
+  isDub?: boolean;
+  fanSub?: string;
+};
+
+export type PaheSourceResponse = {
+  animeSession: string;
+  episodeSession: string;
+  play?: {
+    session?: string;
+    provider?: string;
+    episode?: string;
+    anime_title?: string;
+    sources?: PaheSource[];
+    downloads?: unknown[];
+  };
+};
+
+type FetchState<T> = {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function encodePaheSessions(animeSession: string, episodeSession: string) {
+  const payload = `${animeSession}::${episodeSession}`;
+
+  if (typeof btoa === "function") {
+    return btoa(payload);
+  }
+
+  return Buffer.from(payload, "utf-8").toString("base64");
+}
+
+function normalizePaheSourceResponse(payload: any): PaheSourceResponse | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  return payload as PaheSourceResponse;
+}
+
+function getSourceResolution(source?: PaheSource | null) {
+  return Number.parseInt(source?.resolution || "0", 10) || 0;
+}
+
+type JikanEpisode = {
+  mal_id: number;
+  url?: string;
+  title?: string;
+  title_japanese?: string;
+  title_romanji?: string;
+  aired?: string;
+  score?: number;
+  filler?: boolean;
+  recap?: boolean;
+  forum_url?: string;
+};
+
+type JikanEpisodeResponse = {
+  pagination?: {
+    last_visible_page?: number;
+    has_next_page?: boolean;
+  };
+  data?: JikanEpisode[];
+};
+
+function normalizeJikanEpisodes(payload: JikanEpisodeResponse, malId: string | number) {
+  const episodes = Array.isArray(payload?.data) ? payload.data : [];
+
+  return {
+    anilistId: 0,
+    paheId: Number.parseInt(String(malId), 10) || 0,
+    session: String(malId),
+    type: "anime",
+    title: "",
+    episodes: episodes.map((episode) => ({
+      id: episode.mal_id,
+      episode: episode.mal_id,
+      session: String(episode.mal_id),
+      link: episode.url,
+      title: episode.title || episode.title_romanji || `Episode ${episode.mal_id}`,
+    })),
+  } satisfies PaheEpisodeListResponse;
+}
+
+async function fetchJikanEpisodePage(malId: string | number, page: number) {
+  const response = await fetch(
+    `https://api.jikan.moe/v4/anime/${encodeURIComponent(String(malId))}/episodes?page=${page}`,
+    {
+      headers: {
+        Accept: "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to load Jikan episodes (${response.status}).`);
+  }
+
+  return response.json() as Promise<JikanEpisodeResponse>;
+}
+
+async function fetchAllJikanEpisodes(malId: string | number) {
+  const firstPage = await fetchJikanEpisodePage(malId, 1);
+  const lastVisiblePage = firstPage.pagination?.last_visible_page || 1;
+
+  if (lastVisiblePage <= 1) {
+    return firstPage;
+  }
+
+  const remainingPages = await Promise.all(
+    Array.from({ length: lastVisiblePage - 1 }, (_, index) =>
+      fetchJikanEpisodePage(malId, index + 2),
+    ),
+  );
+
+  return {
+    ...firstPage,
+    data: [
+      ...(firstPage.data || []),
+      ...remainingPages.flatMap((page) => page.data || []),
+    ],
+  } satisfies JikanEpisodeResponse;
+}
+
+export function pickPaheSource(
+  response: PaheSourceResponse | null,
+  preferredLanguage: string = "sub",
+) {
+  const sources = Array.isArray(response?.play?.sources)
+    ? response?.play?.sources
+    : [];
+
+  const preferredSources = sources.filter((source) => {
+    if (preferredLanguage.toLowerCase() === "dub") {
+      return !!source?.isDub;
+    }
+
+    return !source?.isDub;
+  });
+
+  const candidates = preferredSources.length > 0 ? preferredSources : sources;
+
+  return candidates
+    .slice()
+    .sort((left, right) => getSourceResolution(right) - getSourceResolution(left))[0] || null;
+}
+
+export async function fetchPaheEpisodes(
+  malId: string | number,
+): Promise<PaheEpisodeListResponse> {
+  const response = await fetchAllJikanEpisodes(malId);
+  return normalizeJikanEpisodes(response, malId);
+}
+
+export async function fetchPaheSources(
+  animeSession: string,
+  episodeSession: string,
+): Promise<PaheSourceResponse> {
+  if (!PAHE_API_URL) {
+    throw new Error("PAHE API URL is not configured.");
+  }
+
+  const encodedSessions = encodePaheSessions(animeSession, episodeSession);
+  const response = await fetch(`${PAHE_API_URL}api/sources/${encodedSessions}`, {
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load PAHE sources (${response.status}).`);
+  }
+
+  return response.json();
+}
+
+export function usePaheEpisodes(anilistId?: string | number) {
+  const [state, setState] = useState<FetchState<PaheEpisodeListResponse>>({
+    data: null,
+    loading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!anilistId) {
+      setState({ data: null, loading: false, error: null });
+      return;
+    }
+
+    let active = true;
+
+    setState({ data: null, loading: true, error: null });
+
+    fetchPaheEpisodes(anilistId)
+      .then((data) => {
+        if (!active) return;
+        setState({ data, loading: false, error: null });
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        setState({
+          data: null,
+          loading: false,
+          error: error instanceof Error ? error.message : "Failed to load PAHE episodes.",
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [anilistId]);
+
+  return state;
+}
+
+export function usePaheSources(
+  animeSession?: string,
+  episodeSession?: string,
+  preferredLanguage: string = "sub",
+) {
+  const [state, setState] = useState<FetchState<PaheSourceResponse>>({
+    data: null,
+    loading: false,
+    error: null,
+  });
+
+  const shouldLoad = Boolean(animeSession && episodeSession);
+
+  useEffect(() => {
+    if (!shouldLoad || !animeSession || !episodeSession) {
+      setState({ data: null, loading: false, error: null });
+      return;
+    }
+
+    let active = true;
+
+    setState({ data: null, loading: true, error: null });
+
+    fetchPaheSources(animeSession, episodeSession)
+      .then((data) => {
+        if (!active) return;
+        setState({ data: normalizePaheSourceResponse(data), loading: false, error: null });
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        setState({
+          data: null,
+          loading: false,
+          error: error instanceof Error ? error.message : "Failed to load PAHE sources.",
+        });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [animeSession, episodeSession, shouldLoad]);
+
+  return {
+    ...state,
+    selectedSource: useMemo(
+      () => pickPaheSource(state.data, preferredLanguage),
+      [preferredLanguage, state.data],
+    ),
+  };
+}

--- a/tests/hooks/usePaheApi.test.ts
+++ b/tests/hooks/usePaheApi.test.ts
@@ -1,0 +1,59 @@
+import { test, expect } from 'bun:test';
+import { encodePaheSessions, fetchPaheEpisodes, pickPaheSource } from '@/hooks/usePaheApi';
+
+test('encodePaheSessions base64 encodes both sessions', () => {
+  expect(encodePaheSessions('anime-session', 'episode-session')).toBe(
+    'YW5pbWUtc2Vzc2lvbjo6ZXBpc29kZS1zZXNzaW9u',
+  );
+});
+
+test('pickPaheSource prefers the requested language and highest resolution', () => {
+  const selected = pickPaheSource(
+    {
+      animeSession: 'anime-session',
+      episodeSession: 'episode-session',
+      play: {
+        sources: [
+          { url: 'https://example.com/sub-360.m3u8', resolution: '360', isDub: false },
+          { url: 'https://example.com/sub-1080.m3u8', resolution: '1080', isDub: false },
+          { url: 'https://example.com/dub-720.m3u8', resolution: '720', isDub: true },
+        ],
+      },
+    },
+    'sub',
+  );
+
+  expect(selected?.url).toBe('https://example.com/sub-1080.m3u8');
+});
+
+test('fetchPaheEpisodes maps Jikan episodes into the existing episode shape', async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (async () => ({
+    ok: true,
+    json: async () => ({
+      pagination: {
+        last_visible_page: 1,
+        has_next_page: false,
+      },
+      data: [
+        {
+          mal_id: 1,
+          title: 'You Aren\'t E-Rank, Are You?',
+          url: 'https://example.com/episode/1',
+        },
+      ],
+    }),
+  })) as typeof fetch;
+
+  try {
+    const response = await fetchPaheEpisodes(58567);
+
+    expect(response.session).toBe('58567');
+    expect(response.episodes).toHaveLength(1);
+    expect(response.episodes[0].episode).toBe(1);
+    expect(response.episodes[0].title).toBe('You Aren\'t E-Rank, Are You?');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
…or episode fetching

- Updated WatchPage to utilize the new usePaheEpisodes hook for fetching episodes.
- Simplified episode state management and error handling in WatchPage.
- Refactored UnifiedPlayer to use an iframe for video playback, removing the previous HLS implementation.
- Added new usePaheApi hook for fetching episodes and sources from the Pahe API.
- Implemented tests for encoding sessions, selecting sources, and fetching episodes.
- Removed unused imports and code related to previous streaming methods.